### PR TITLE
Change the operation of CLI

### DIFF
--- a/src/dbusservice/dbusscreenshotservice.cpp
+++ b/src/dbusservice/dbusscreenshotservice.cpp
@@ -72,39 +72,3 @@ void DBusScreenshotService::DelayScreenshot(qlonglong in0)
     m_singleInstance = true;
 }
 
-void DBusScreenshotService::NoNotifyScreenshot()
-{
-     qDebug() << "DBus screenshot service! nonofiy screenshot";
-    // handle method call com.deepin.Screenshot.NoNotify
-     if (!m_singleInstance)
-        parent()->noNotifyScreenshot();
-     m_singleInstance = true;
-}
-
-void DBusScreenshotService::TopWindowScreenshot()
-{
-     qDebug() << "DBus screenshot service! topWindow screenshot";
-    // handle method call com.deepin.Screenshot.TopWindow
-     if (!m_singleInstance)
-        parent()->topWindowScreenshot();
-     m_singleInstance = true;
-}
-
-void DBusScreenshotService::FullscreenScreenshot()
-{
-     qDebug() << "DBus screenshot service! Fullscreen screenshot";
-    // handle method call com.deepin.Screenshot.Fullscreenshot
-     if (!m_singleInstance)
-        parent()->fullscreenScreenshot();
-     m_singleInstance = true;
-}
-
-void DBusScreenshotService::SavePathScreenshot(const QString &in0)
-{
-     qDebug() << "DBus screenshot service! SavePath screenshot";
-    // handle method call com.deepin.Screenshot.SavePath
-     if (!m_singleInstance)
-        parent()->savePathScreenshot(in0);
-     m_singleInstance = true;
-}
-

--- a/src/dbusservice/dbusscreenshotservice.cpp
+++ b/src/dbusservice/dbusscreenshotservice.cpp
@@ -63,12 +63,12 @@ void DBusScreenshotService::StartScreenshot() {
     m_singleInstance = true;
 }
 
-void DBusScreenshotService::DelayScreenshot(qlonglong in0)
+void DBusScreenshotService::ScreenshotWithOptions(double delay, int areaOption, const QString &savePath, bool noNotify)
 {
     qDebug() << "DBus screenshot service! delay screenshot";
     // handle method call com.deepin.Screenshot.DelayScreenshot
     if (!m_singleInstance)
-        parent()->delayScreenshot(in0);
+        parent()->screenshotWithOptions(delay, areaOption, savePath, noNotify);
     m_singleInstance = true;
 }
 

--- a/src/dbusservice/dbusscreenshotservice.h
+++ b/src/dbusservice/dbusscreenshotservice.h
@@ -79,10 +79,6 @@ public: // PROPERTIES
 public Q_SLOTS: // METHODS
     void StartScreenshot();
     void DelayScreenshot(qlonglong in0);
-    void NoNotifyScreenshot();
-    void TopWindowScreenshot();
-    void FullscreenScreenshot();
-    void SavePathScreenshot(const QString &in0);
 Q_SIGNALS: // SIGNALS
 private:
     bool m_singleInstance;

--- a/src/dbusservice/dbusscreenshotservice.h
+++ b/src/dbusservice/dbusscreenshotservice.h
@@ -78,7 +78,7 @@ public:
 public: // PROPERTIES
 public Q_SLOTS: // METHODS
     void StartScreenshot();
-    void DelayScreenshot(qlonglong in0);
+    void ScreenshotWithOptions(double delay, int areaOption, const QString &savePath, bool noNotify);
 Q_SIGNALS: // SIGNALS
 private:
     bool m_singleInstance;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,30 +92,43 @@ int main(int argc, char *argv[])
          return 0;
      }
 
-     if (cmdParser.isSet(dbusOption))
+     if (argc == 1){
+         w.startScreenshot();
+     }else if (cmdParser.isSet(dbusOption))
      {
          qDebug() << "dbus register waiting!";
          return a.exec();
-     } else {
-         if (cmdParser.isSet(delayOption)) {
-             qDebug() << "cmd delay screenshot";
-             w.delayScreenshot(cmdParser.value(delayOption).toInt());
-         } else if (cmdParser.isSet(fullscreenOption)) {
-             w.fullscreenScreenshot();
-         } else if (cmdParser.isSet(topWindowOption)) {
-             qDebug() << "cmd topWindow screenshot";
-             w.topWindowScreenshot();
-         } else if (cmdParser.isSet(savePathOption)) {
-             qDebug() << "cmd savepath screenshot";
-             w.savePathScreenshot(cmdParser.value(savePathOption));
-         } else if (cmdParser.isSet(prohibitNotifyOption)) {
+     }else if (cmdParser.isSet(iconOption)) {
+             w.delayScreenshot(0.2);
+     }else if (cmdParser.isSet(prohibitNotifyOption)) {
              qDebug() << "screenshot no notify!";
              w.noNotifyScreenshot();
-         } else if (cmdParser.isSet(iconOption)) {
-             w.delayScreenshot(0.2);
-         }  else {
-             w.startScreenshot();
+     }
+     else {
+         int delay=0;
+         int areaOption=1;
+         QString savePath="";
+         if (cmdParser.isSet(delayOption)) {
+             qDebug() << "cmd delay screenshot";
+             delay = cmdParser.value(delayOption).toInt();
+         } 
+         if (cmdParser.isSet(fullscreenOption)) {
+             areaOption=1;
          }
+         if (cmdParser.isSet(topWindowOption)) {
+             qDebug() << "cmd topWindow screenshot";
+             areaOption=2;
+         }
+         if (cmdParser.isSet(savePathOption)) {
+             qDebug() << "cmd savepath screenshot";
+             savePath=cmdParser.value(savePathOption);
+             if (!QFileInfo(savePath).dir().exists()) {
+                qDebug() << "Error: path does not exist!";
+                return 0;
+             }
+         }
+         
+         w.multioptionalScreenshot(delay, areaOption, savePath);
      }
 
      return a.exec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,101 +35,100 @@ int main(int argc, char *argv[])
     DWIDGET_INIT_RESOURCE();
 #endif
 
-     DApplication::loadDXcbPlugin();
+    DApplication::loadDXcbPlugin();
 
-     DApplication a(argc, argv);
-     a.loadTranslator(QList<QLocale>() << QLocale::system());
-     a.setOrganizationName("deepin");
-     a.setApplicationName("deepin-screenshot");
-     a.setApplicationVersion("4.0");
-     a.setTheme("light");
-     a.setQuitOnLastWindowClosed(false);
-     a.setAttribute(Qt::AA_UseHighDpiPixmaps);
+    DApplication a(argc, argv);
+    a.loadTranslator(QList<QLocale>() << QLocale::system());
+    a.setOrganizationName("deepin");
+    a.setApplicationName("deepin-screenshot");
+    a.setApplicationVersion("4.0");
+    a.setTheme("light");
+    a.setQuitOnLastWindowClosed(false);
+    a.setAttribute(Qt::AA_UseHighDpiPixmaps);
 
-     using namespace Dtk::Core;
-     Dtk::Core::DLogManager::registerConsoleAppender();
-     Dtk::Core::DLogManager::registerFileAppender();
+    using namespace Dtk::Core;
+    Dtk::Core::DLogManager::registerConsoleAppender();
+    Dtk::Core::DLogManager::registerFileAppender();
 
-     QCommandLineOption  delayOption(QStringList() << "d" << "delay",
+    QCommandLineOption  delayOption(QStringList() << "d" << "delay",
                                                                              "Take a screenshot after NUM seconds.", "NUM");
-     QCommandLineOption fullscreenOption(QStringList() << "f" << "fullscreen",
+    QCommandLineOption fullscreenOption(QStringList() << "f" << "fullscreen",
                                                                                 "Take a screenshot the whole screen.");
-     QCommandLineOption topWindowOption(QStringList() << "w" << "top-window",
+    QCommandLineOption topWindowOption(QStringList() << "w" << "top-window",
                                                                              "Take a screenshot of the most top window.");
-     QCommandLineOption savePathOption(QStringList() << "s" << "save-path",
+    QCommandLineOption savePathOption(QStringList() << "s" << "save-path",
                                                                              "Specify a path to save the screenshot.", "PATH");
-     QCommandLineOption prohibitNotifyOption(QStringList() << "n" << "no-notification",
+    QCommandLineOption prohibitNotifyOption(QStringList() << "n" << "no-notification",
                                                                               "Don't send notifications.");
-     QCommandLineOption iconOption(QStringList() << "i" << "icon",
+    QCommandLineOption iconOption(QStringList() << "i" << "icon",
                                                                            "Indicate that this program's started by clicking.");
     QCommandLineOption dbusOption(QStringList() << "u" << "dbus",
                                                                             "Start  from dbus.");
-     QCommandLineParser cmdParser;
-     cmdParser.setApplicationDescription("deepin-screenshot");
-     cmdParser.addHelpOption();
-     cmdParser.addVersionOption();
-     cmdParser.addOption(delayOption);
-     cmdParser.addOption(fullscreenOption);
-     cmdParser.addOption(topWindowOption);
-     cmdParser.addOption(savePathOption);
-     cmdParser.addOption(prohibitNotifyOption);
-     cmdParser.addOption(iconOption);
-     cmdParser.addOption(dbusOption);
-     cmdParser.process(a);
+    QCommandLineParser cmdParser;
+    cmdParser.setApplicationDescription("deepin-screenshot");
+    cmdParser.addHelpOption();
+    cmdParser.addVersionOption();
+    cmdParser.addOption(delayOption);
+    cmdParser.addOption(fullscreenOption);
+    cmdParser.addOption(topWindowOption);
+    cmdParser.addOption(savePathOption);
+    cmdParser.addOption(prohibitNotifyOption);
+    cmdParser.addOption(iconOption);
+    cmdParser.addOption(dbusOption);
+    cmdParser.process(a);
 
-     Screenshot w;
-     w.hide();
+    Screenshot w;
+    w.hide();
 
-     DBusScreenshotService dbusService (&w);
-     Q_UNUSED(dbusService);
+    DBusScreenshotService dbusService (&w);
+    Q_UNUSED(dbusService);
      //Register Screenshot's dbus service.
-     QDBusConnection conn = QDBusConnection::sessionBus();
-     if (!conn.registerService("com.deepin.Screenshot") ||
-             !conn.registerObject("/com/deepin/Screenshot", &w)) {
-         qDebug() << "deepin-screenshot is running!";
+    QDBusConnection conn = QDBusConnection::sessionBus();
+    if (!conn.registerService("com.deepin.Screenshot") ||
+            !conn.registerObject("/com/deepin/Screenshot", &w)) {
+        qDebug() << "deepin-screenshot is running!";
 
-         qApp->quit();
-         return 0;
-     }
+        qApp->quit();
+        return 0;
+    }
 
-     if (argc == 1){
-         w.startScreenshot();
-     }else if (cmdParser.isSet(dbusOption))
-     {
-         qDebug() << "dbus register waiting!";
-         return a.exec();
-     }else if (cmdParser.isSet(iconOption)) {
-             w.delayScreenshot(0.2);
-     }else if (cmdParser.isSet(prohibitNotifyOption)) {
-             qDebug() << "screenshot no notify!";
-             w.noNotifyScreenshot();
-     }
-     else {
-         int delay=0;
-         int areaOption=1;
-         QString savePath="";
-         if (cmdParser.isSet(delayOption)) {
-             qDebug() << "cmd delay screenshot";
-             delay = cmdParser.value(delayOption).toInt();
-         } 
-         if (cmdParser.isSet(fullscreenOption)) {
-             areaOption=1;
-         }
-         if (cmdParser.isSet(topWindowOption)) {
-             qDebug() << "cmd topWindow screenshot";
-             areaOption=2;
-         }
-         if (cmdParser.isSet(savePathOption)) {
-             qDebug() << "cmd savepath screenshot";
-             savePath=cmdParser.value(savePathOption);
-             if (!QFileInfo(savePath).dir().exists()) {
+    if (argc == 1) {
+        w.startScreenshot();
+    }else if (cmdParser.isSet(dbusOption)) {
+        qDebug() << "dbus register waiting!";
+        return a.exec();
+    }else if (cmdParser.isSet(iconOption)) {
+            w.delayScreenshot(0.2);
+    }else if (cmdParser.isSet(prohibitNotifyOption)) {
+        qDebug() << "screenshot no notify!";
+        w.noNotifyScreenshot();
+    }
+    else {
+        int delay=0;
+        int areaOption=1;
+        QString savePath="";
+        if (cmdParser.isSet(delayOption)) {
+            qDebug() << "cmd delay screenshot";
+            delay = cmdParser.value(delayOption).toInt();
+        } 
+        if (cmdParser.isSet(fullscreenOption)) {
+            areaOption=1;
+        }
+        if (cmdParser.isSet(topWindowOption)) {
+            qDebug() << "cmd topWindow screenshot";
+            areaOption=2;
+        }
+        if (cmdParser.isSet(savePathOption)) {
+            qDebug() << "cmd savepath screenshot";
+            savePath=cmdParser.value(savePathOption);
+            if (!QFileInfo(savePath).dir().exists()) {
                 qDebug() << "Error: path does not exist!";
                 return 0;
-             }
-         }
+            }
+        }
          
-         w.multioptionalScreenshot(delay, areaOption, savePath);
-     }
+        w.multioptionalScreenshot(delay, areaOption, savePath);
+    }
 
-     return a.exec();
+    return a.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,11 +96,12 @@ int main(int argc, char *argv[])
     }else if (cmdParser.isSet(dbusOption)) {
         qDebug() << "dbus register waiting!";
         return a.exec();
-    }else if (cmdParser.isSet(iconOption)) {
-            w.delayScreenshot(0.2);
     }
+    //else if (cmdParser.isSet(iconOption)) {
+    //        w.screenshotWithOptions(0.2);
+    //}
     else {
-        int delay=0;
+        double delay=0;
         int areaOption=0;
         QString savePath="";
         bool noNotify=false;
@@ -128,7 +129,9 @@ int main(int argc, char *argv[])
             qDebug() << "screenshot no notify!";
             noNotify=true;
         }
-         
+        if (cmdParser.isSet(iconOption)) {
+            delay = 0.2;
+	}
         w.screenshotWithOptions(delay, areaOption, savePath, noNotify);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     QCommandLineOption iconOption(QStringList() << "i" << "icon",
                                                                            "Indicate that this program's started by clicking.");
     QCommandLineOption dbusOption(QStringList() << "u" << "dbus",
-                                                                            "Start  from dbus.");
+                                                                            "Start from dbus.");
     QCommandLineParser cmdParser;
     cmdParser.setApplicationDescription("deepin-screenshot");
     cmdParser.addHelpOption();
@@ -87,7 +87,6 @@ int main(int argc, char *argv[])
     if (!conn.registerService("com.deepin.Screenshot") ||
             !conn.registerObject("/com/deepin/Screenshot", &w)) {
         qDebug() << "deepin-screenshot is running!";
-
         qApp->quit();
         return 0;
     }
@@ -127,7 +126,7 @@ int main(int argc, char *argv[])
             }
         }
          
-        w.multioptionalScreenshot(delay, areaOption, savePath);
+        w.screenshotWithOptions(delay, areaOption, savePath);
     }
 
     return a.exec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,19 +98,18 @@ int main(int argc, char *argv[])
         return a.exec();
     }else if (cmdParser.isSet(iconOption)) {
             w.delayScreenshot(0.2);
-    }else if (cmdParser.isSet(prohibitNotifyOption)) {
-        qDebug() << "screenshot no notify!";
-        w.noNotifyScreenshot();
     }
     else {
         int delay=0;
-        int areaOption=1;
+        int areaOption=0;
         QString savePath="";
+        bool noNotify=false;
         if (cmdParser.isSet(delayOption)) {
             qDebug() << "cmd delay screenshot";
             delay = cmdParser.value(delayOption).toInt();
-        } 
+        }
         if (cmdParser.isSet(fullscreenOption)) {
+            qDebug() << "cmd fullscreen screenshot";
             areaOption=1;
         }
         if (cmdParser.isSet(topWindowOption)) {
@@ -125,8 +124,12 @@ int main(int argc, char *argv[])
                 return 0;
             }
         }
+        if (cmdParser.isSet(prohibitNotifyOption)) {
+            qDebug() << "screenshot no notify!";
+            noNotify=true;
+        }
          
-        w.screenshotWithOptions(delay, areaOption, savePath);
+        w.screenshotWithOptions(delay, areaOption, savePath, noNotify);
     }
 
     return a.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1115,8 +1115,9 @@ void MainWindow::expressSaveScreenshot()
     }
 }
 
-void MainWindow::screenshotWithOptions(int areaOption, const QString &path){
+void MainWindow::screenshotWithOptions(int areaOption, const QString &path, bool noNotify) {
     m_saveFileName = path;
+    m_noNotify = noNotify;
     if (areaOption == 0) {
         if (path.length() == 0)
             startScreenshot();
@@ -1413,15 +1414,16 @@ bool MainWindow::saveAction(const QPixmap &pix)
     return true;
 }
 
-void MainWindow::sendNotify(int saveIndex, QString saveFilePath, const bool succeed)
+void MainWindow::sendNotify(int saveIndex, const QString &saveFilePath, const bool succeed)
 {
     // failed notify
     if (!succeed)
     {
-        const auto tips = tr("Save failed. Please save it in your home directory.");
-        m_notifyDBInterface->Notify("Deepin Screenshot", 0, "deepin-screenshot", QString(), tips, QStringList(), QVariantMap(), 0);
-
-	exit(0);
+        if(!m_noNotify) {
+            const auto tips = tr("Save failed. Please save it in your home directory.");
+            m_notifyDBInterface->Notify("Deepin Screenshot", 0, "deepin-screenshot", QString(), tips, QStringList(), QVariantMap(), 0);
+        }
+	    exit(0);
     }
 
     QDBusInterface remote_dde_notify_obj("com.deepin.dde.Notification", "/com/deepin/dde/Notification",

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -935,8 +935,7 @@ void MainWindow::fullScreenshot(QString savePath)
 
     TempFile::instance()->setFullScreenPixmap(m_resultPixmap);
     const auto r = saveAction(m_resultPixmap);
-    if(!m_noNotify)
-        sendNotify(m_saveIndex, m_saveFileName, r);
+    sendNotify(m_saveIndex, m_saveFileName, r);
 }
 
 void MainWindow::savePath(const QString &path)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -897,12 +897,16 @@ void MainWindow::resizeDirection(ResizeDirection direction, QMouseEvent *e)
     }
 }
 
-void MainWindow::fullScreenshot()
+void MainWindow::fullScreenshot(QString savePath)
 {
+    if(savePath.length() != 0)
+        m_saveFileName = savePath;
+
+    initDBusInterface();
+
     m_mouseStatus = ShotMouseStatus::Shoting;
     repaint();
     qApp->setOverrideCursor(setCursorShape("start"));
-    initDBusInterface();
     this->setFocus();
     m_configSettings =  ConfigSettings::instance();
     installEventFilter(this);
@@ -931,7 +935,8 @@ void MainWindow::fullScreenshot()
 
     TempFile::instance()->setFullScreenPixmap(m_resultPixmap);
     const auto r = saveAction(m_resultPixmap);
-    sendNotify(m_saveIndex, m_saveFileName, r);
+    if(!m_noNotify)
+        sendNotify(m_saveIndex, m_saveFileName, r);
 }
 
 void MainWindow::savePath(const QString &path)
@@ -1058,8 +1063,11 @@ void MainWindow::noNotify()
     initShortcut();
 }
 
-void MainWindow::topWindow()
+void MainWindow::topWindow(QString savePath)
 {
+    if(savePath.length() != 0)
+        m_saveFileName = savePath;
+
     initOriginUI();
     this->show();
     initSecondUI();
@@ -1222,6 +1230,12 @@ bool MainWindow::saveAction(const QPixmap &pix)
     QDateTime currentDate;
     QString currentTime =  currentDate.currentDateTime().
             toString("yyyyMMddHHmmss");
+    
+    QString defaultSaveDir;
+    if(m_saveFileName.length() !=0 )
+        defaultSaveDir = QFileInfo(m_saveFileName).dir().absolutePath();
+    else
+        defaultSaveDir = ConfigSettings::instance()->value("common", "default_savepath").toString();
     m_saveFileName = "";
 
     QStandardPaths::StandardLocation saveOption = QStandardPaths::TempLocation;
@@ -1240,7 +1254,7 @@ bool MainWindow::saveAction(const QPixmap &pix)
         break;
     }
     case 1: {
-        QString defaultSaveDir = ConfigSettings::instance()->value("common", "default_savepath").toString();
+        //QString defaultSaveDir = ConfigSettings::instance()->value("common", "default_savepath").toString();
         if (defaultSaveDir.isEmpty()) {
             saveOption = QStandardPaths::DesktopLocation;
         } else if (defaultSaveDir == "clipboard") {
@@ -1297,7 +1311,7 @@ bool MainWindow::saveAction(const QPixmap &pix)
     }
     case 4: {
         copyToClipboard = true;
-        QString defaultSaveDir = ConfigSettings::instance()->value("common", "default_savepath").toString();
+        //QString defaultSaveDir = ConfigSettings::instance()->value("common", "default_savepath").toString();
         if (defaultSaveDir.isEmpty()) {
             saveOption = QStandardPaths::DesktopLocation;
         } else if (defaultSaveDir == "clipboard") {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -81,16 +81,17 @@ signals:
     void updateZoom();
 
 public slots:
-    void fullScreenshot(QString savePath="");
+    void fullScreenshot();
     void savePath(const QString &path);
     void saveSpecificedPath(QString path);
 //    void delayScreenshot(int num);
     void noNotify();
-    void topWindow(QString savePath="");
+    void topWindow();
     void expressSaveScreenshot();
     //Indicate that this program's started by clicking desktop file.
      //void startByIcon();
 
+    void screenshotWithOptions(int areaOption, const QString &savePath);
     void startScreenshot();
     void shotFullScreen();
     void shotCurrentImg();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -81,12 +81,12 @@ signals:
     void updateZoom();
 
 public slots:
-    void fullScreenshot();
+    void fullScreenshot(QString savePath="");
     void savePath(const QString &path);
     void saveSpecificedPath(QString path);
 //    void delayScreenshot(int num);
     void noNotify();
-    void topWindow();
+    void topWindow(QString savePath="");
     void expressSaveScreenshot();
     //Indicate that this program's started by clicking desktop file.
      //void startByIcon();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -91,14 +91,14 @@ public slots:
     //Indicate that this program's started by clicking desktop file.
      //void startByIcon();
 
-    void screenshotWithOptions(int areaOption, const QString &savePath);
+    void screenshotWithOptions(int areaOption, const QString &savePath, bool noNotify);
     void startScreenshot();
     void shotFullScreen();
     void shotCurrentImg();
     void shotImgWidthEffect();
     void saveScreenshot();
     bool saveAction(const QPixmap &pix);
-    void sendNotify(int saveIndex, QString saveFilePath, const bool succeed);
+    void sendNotify(int saveIndex, const QString &saveFilePath, const bool succeed);
     void reloadImage(QString effect);
     void onViewShortcut();
     void onHelp();

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -93,36 +93,7 @@ void Screenshot::delayScreenshot(double num)
     });
 }
 
-void Screenshot::fullscreenScreenshot()
-{
-    initUI();
-    this->show();
-    m_window->fullScreenshot();
-}
-
-void Screenshot::topWindowScreenshot()
-{
-    initUI();
-    this->show();
-    m_window->topWindow();
-}
-
-void Screenshot::noNotifyScreenshot()
-{
-    initUI();
-    this->show();
-    m_window->noNotify();
-}
-
-void Screenshot::savePathScreenshot(const QString &path)
-{
-    initUI();
-    this->show();
-    m_window->savePath(path);
-}
-
-
-void Screenshot::screenshotWithOptions(int delay, int areaOption, const QString &savePath)
+void Screenshot::screenshotWithOptions(int delay, int areaOption, const QString &savePath, bool noNotify)
 {
     QString summary = QString(tr("Deepin Screenshot will start after %1 seconds").arg(delay));
     QStringList actions = QStringList();
@@ -134,16 +105,16 @@ void Screenshot::screenshotWithOptions(int delay, int areaOption, const QString 
         QTimer* timer = new QTimer();
         timer->setSingleShot(true);
         timer->start(int(1000*delay));
-        notifyDBus->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
-                                summary, actions, hints, 0);
+        if (!noNotify)
+            notifyDBus->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
+                                    summary, actions, hints, 0);
         connect(timer, &QTimer::timeout, this, [=]{
             notifyDBus->CloseNotification(0);
-            m_window->screenshotWithOptions(areaOption, savePath);
+            m_window->screenshotWithOptions(areaOption, savePath, noNotify);
         });
-
     }
     else {
-        m_window->screenshotWithOptions(areaOption, savePath);
+        m_window->screenshotWithOptions(areaOption, savePath, noNotify);
     }
 }
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -121,22 +121,15 @@ void Screenshot::savePathScreenshot(const QString &path)
     m_window->savePath(path);
 }
 
-void Screenshot::multioptionalScreenshot(int areaOption, QString savePath){
-    initUI();
-    this->show();
-    if(areaOption == 1){
-        m_window->fullScreenshot(savePath);
-    }
-    else if(areaOption == 2){
-        m_window->topWindow(savePath);
-    }
-}
 
-void Screenshot::multioptionalScreenshot(int delay, int areaOption, QString savePath){
+void Screenshot::screenshotWithOptions(int delay, int areaOption, const QString &savePath)
+{
     QString summary = QString(tr("Deepin Screenshot will start after %1 seconds").arg(delay));
     QStringList actions = QStringList();
     QVariantMap hints;
     DBusNotify* notifyDBus = new DBusNotify(this);
+    initUI();
+    this->show();
     if (delay >= 1) {
         QTimer* timer = new QTimer();
         timer->setSingleShot(true);
@@ -145,12 +138,12 @@ void Screenshot::multioptionalScreenshot(int delay, int areaOption, QString save
                                 summary, actions, hints, 0);
         connect(timer, &QTimer::timeout, this, [=]{
             notifyDBus->CloseNotification(0);
-            multioptionalScreenshot(areaOption, savePath);
+            m_window->screenshotWithOptions(areaOption, savePath);
         });
 
     }
-    else{
-        multioptionalScreenshot(areaOption, savePath);
+    else {
+        m_window->screenshotWithOptions(areaOption, savePath);
     }
 }
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -121,6 +121,39 @@ void Screenshot::savePathScreenshot(const QString &path)
     m_window->savePath(path);
 }
 
+void Screenshot::multioptionalScreenshot(int areaOption, QString savePath){
+    initUI();
+    this->show();
+    if(areaOption == 1){
+        m_window->fullScreenshot(savePath);
+    }
+    else if(areaOption == 2){
+        m_window->topWindow(savePath);
+    }
+}
+
+void Screenshot::multioptionalScreenshot(int delay, int areaOption, QString savePath){
+    QString summary = QString(tr("Deepin Screenshot will start after %1 seconds").arg(delay));
+    QStringList actions = QStringList();
+    QVariantMap hints;
+    DBusNotify* notifyDBus = new DBusNotify(this);
+    if (delay >= 1) {
+        QTimer* timer = new QTimer();
+        timer->setSingleShot(true);
+        timer->start(int(1000*delay));
+        notifyDBus->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
+                                summary, actions, hints, 0);
+        connect(timer, &QTimer::timeout, this, [=]{
+            notifyDBus->CloseNotification(0);
+            multioptionalScreenshot(areaOption, savePath);
+        });
+
+    }
+    else{
+        multioptionalScreenshot(areaOption, savePath);
+    }
+}
+
 bool Screenshot::eventFilter(QObject* watched, QEvent *event)
 {
     Q_UNUSED(watched);

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -73,27 +73,7 @@ void Screenshot::startScreenshot()
     m_window->startScreenshot();
 }
 
-void Screenshot::delayScreenshot(double num)
-{
-    QString summary = QString(tr("Deepin Screenshot will start after %1 seconds").arg(num));
-    QStringList actions = QStringList();
-    QVariantMap hints;
-    DBusNotify* notifyDBus = new DBusNotify(this);
-    if (num >= 2) {
-        notifyDBus->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
-                                    summary, actions, hints, 0);
-    }
-
-    QTimer* timer = new QTimer;
-    timer->setSingleShot(true);
-    timer->start(int(1000*num));
-    connect(timer, &QTimer::timeout, this, [=]{
-        notifyDBus->CloseNotification(0);
-        startScreenshot();
-    });
-}
-
-void Screenshot::screenshotWithOptions(int delay, int areaOption, const QString &savePath, bool noNotify)
+void Screenshot::screenshotWithOptions(double delay, int areaOption, const QString &savePath, bool noNotify)
 {
     QString summary = QString(tr("Deepin Screenshot will start after %1 seconds").arg(delay));
     QStringList actions = QStringList();
@@ -101,11 +81,11 @@ void Screenshot::screenshotWithOptions(int delay, int areaOption, const QString 
     DBusNotify* notifyDBus = new DBusNotify(this);
     initUI();
     this->show();
-    if (delay >= 1) {
+    if (delay + 0.000005 >= 0) {
         QTimer* timer = new QTimer();
         timer->setSingleShot(true);
         timer->start(int(1000*delay));
-        if (!noNotify)
+        if (!noNotify && delay + 0.000005 > 2)
             notifyDBus->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
                                     summary, actions, hints, 0);
         connect(timer, &QTimer::timeout, this, [=]{

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -36,7 +36,8 @@ public slots:
     void topWindowScreenshot();
     void noNotifyScreenshot();
     void savePathScreenshot(const QString &path);
-
+    void multioptionalScreenshot(int delay, int areaOption, QString savePath);
+    void multioptionalScreenshot(int areaOption, QString savePath);
 protected:
     bool  eventFilter(QObject* watched, QEvent* event) override;
 

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -36,8 +36,7 @@ public slots:
     void topWindowScreenshot();
     void noNotifyScreenshot();
     void savePathScreenshot(const QString &path);
-    void multioptionalScreenshot(int delay, int areaOption, QString savePath);
-    void multioptionalScreenshot(int areaOption, QString savePath);
+    void screenshotWithOptions(int delay, int areaOption, const QString &savePath);
 protected:
     bool  eventFilter(QObject* watched, QEvent* event) override;
 

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -31,8 +31,7 @@ public:
 
 public slots:
     void startScreenshot();
-    void delayScreenshot(double num);
-    void screenshotWithOptions(int delay, int areaOption, const QString &savePath, bool noNotify);
+    void screenshotWithOptions(double delay, int areaOption, const QString &savePath, bool noNotify);
 protected:
     bool  eventFilter(QObject* watched, QEvent* event) override;
 

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -32,11 +32,7 @@ public:
 public slots:
     void startScreenshot();
     void delayScreenshot(double num);
-    void fullscreenScreenshot();
-    void topWindowScreenshot();
-    void noNotifyScreenshot();
-    void savePathScreenshot(const QString &path);
-    void screenshotWithOptions(int delay, int areaOption, const QString &savePath);
+    void screenshotWithOptions(int delay, int areaOption, const QString &savePath, bool noNotify);
 protected:
     bool  eventFilter(QObject* watched, QEvent* event) override;
 


### PR DESCRIPTION
Deepin-screenshot can only use one argument at one time, but sometimes, users may want to get a screenshot and save to  specified path. This PR change the logic on processing arguments, in order to make it possible to use delay, fullscreen/top-window and save-path at the same time.