### PR TITLE
The -s and -n options can now be used together. fixes#22

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,8 @@ int main(int argc, char *argv[])
              w.topWindowScreenshot();
          } else if (cmdParser.isSet(savePathOption)) {
              qDebug() << "cmd savepath screenshot";
-             w.savePathScreenshot(cmdParser.value(savePathOption));
+             w.savePathScreenshot(cmdParser.value(savePathOption), 
+                     cmdParser.isSet(prohibitNotifyOption));
          } else if (cmdParser.isSet(prohibitNotifyOption)) {
              qDebug() << "screenshot no notify!";
              w.noNotifyScreenshot();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -935,8 +935,10 @@ void MainWindow::fullScreenshot()
     sendNotify(m_saveIndex, m_saveFileName, r);
 }
 
-void MainWindow::savePath(const QString &path)
+void MainWindow::savePath(const QString &path, bool noNotify)
 {
+    m_noNotify = noNotify;
+
     if (!QFileInfo(path).dir().exists()) {
         exitApp();
     }
@@ -1017,8 +1019,10 @@ void MainWindow::saveSpecificedPath(QString path)
 
     QString summary = QString(tr("Picture has been saved to %1")).arg(savePath);
 
-    m_notifyDBInterface->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
-                                summary, actions, hints, 0);
+    if (!m_noNotify) {
+        m_notifyDBInterface->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
+                                    summary, actions, hints, 0);
+    }
     exitApp();
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -82,7 +82,7 @@ signals:
 
 public slots:
     void fullScreenshot();
-    void savePath(const QString &path);
+    void savePath(const QString &path, bool noNotify);
     void saveSpecificedPath(QString path);
 //    void delayScreenshot(int num);
     void noNotify();

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -114,11 +114,11 @@ void Screenshot::noNotifyScreenshot()
     m_window->noNotify();
 }
 
-void Screenshot::savePathScreenshot(const QString &path)
+void Screenshot::savePathScreenshot(const QString &path, bool noNotify)
 {
     initUI();
     this->show();
-    m_window->savePath(path);
+    m_window->savePath(path, noNotify);
 }
 
 bool Screenshot::eventFilter(QObject* watched, QEvent *event)

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -35,7 +35,7 @@ public slots:
     void fullscreenScreenshot();
     void topWindowScreenshot();
     void noNotifyScreenshot();
-    void savePathScreenshot(const QString &path);
+    void savePathScreenshot(const QString &path, bool noNotify=false);
 
 protected:
     bool  eventFilter(QObject* watched, QEvent* event) override;


### PR DESCRIPTION
When using the -s and -n options together the -n option was ignored
before.
I added a noNotify argument to the Screenshot::savePathScreenshot
and the MainWindow::savePath functions.
MainWindow::savePath now sets MainWindow::m_noNotify if the program
was called with -n option.
Lastly MainWindow::saveSpecificedPath checks m_noNotify before
sending a notification.