### PR TITLE
fix: can run twice

### DIFF
--- a/src/dbusservice/dbusscreenshotservice.cpp
+++ b/src/dbusservice/dbusscreenshotservice.cpp
@@ -56,6 +56,10 @@ DBusScreenshotService::~DBusScreenshotService()
     // destructor
 }
 
+void DBusScreenshotService::setSingleInstance(bool instance) {
+    m_singleInstance = instance;
+}
+
 void DBusScreenshotService::StartScreenshot() {
     qDebug() << "DBus screenshot service! start screenshot";
     if (!m_singleInstance)
@@ -107,4 +111,3 @@ void DBusScreenshotService::SavePathScreenshot(const QString &in0)
         parent()->savePathScreenshot(in0);
      m_singleInstance = true;
 }
-

--- a/src/dbusservice/dbusscreenshotservice.h
+++ b/src/dbusservice/dbusscreenshotservice.h
@@ -72,6 +72,8 @@ public:
     DBusScreenshotService(Screenshot *parent);
     ~DBusScreenshotService();
 
+    void setSingleInstance(bool instance);
+
     inline Screenshot *parent() const
     { return static_cast<Screenshot *>(QObject::parent()); }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,6 +96,7 @@ int main(int argc, char *argv[])
          qDebug() << "dbus register waiting!";
          return a.exec();
      } else {
+         dbusService.setSingleInstance(true);
          if (cmdParser.isSet(delayOption)) {
              qDebug() << "cmd delay screenshot";
              w.delayScreenshot(cmdParser.value(delayOption).toInt());


### PR DESCRIPTION
dde-daemon针对截图做了特殊处理，可以在grabkeyboard的情况下依旧启动截图，
所以截图的startScreenshot函数被调用了两次，破坏了单例。